### PR TITLE
Update DATABASE_URI

### DIFF
--- a/Guide to Using Databases with Python Postgres, SQLAlchemy, and Alembic/project/config.py
+++ b/Guide to Using Databases with Python Postgres, SQLAlchemy, and Alembic/project/config.py
@@ -1,2 +1,2 @@
 
-DATABASE_URI = 'postgres+psycopg2://postgres:password@localhost:5432/books'
+DATABASE_URI = 'postgresql+psycopg2://postgres:password@localhost:5432/books'


### PR DESCRIPTION
The URI should start with postgresql:// instead of postgres://. SQLAlchemy used to accept both, but has removed support for the postgres name. Sorce: (https://stackoverflow.com/a/64698899/6710864)